### PR TITLE
Make @babel/{core,template} optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,10 +179,18 @@
     "wonka": "^6.3.5"
   },
   "peerDependencies": {
+    "@babel/core": ">=7.0.0",
+    "@babel/template": ">=7.0.0",
     "@types/react": ">=17.0.0",
     "react": ">=17.0.0"
   },
   "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "@babel/template": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     },


### PR DESCRIPTION
Because those imports fail in pnpm

## Related Bug Reports or Discussions

Fixes #3089

## Summary

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
